### PR TITLE
20230803 특정 비율에서 버튼이 컨텐츠와 겹치던 문제 수정/해상도 분기점 변경

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -76,7 +76,7 @@ section {
 	position: relative;
 	width: 90%;
 	height: 40rem;
-	margin: 0 auto;
+	margin: 0 auto 3rem;
 }
 
 article {
@@ -122,7 +122,7 @@ article.thirdBox {
 	line-height: 2rem;
 	text-align: justify;
 	word-break: break-all;
-	overflow: scroll;
+	overflow: auto;
 }
 
 .contentxBox ul {
@@ -146,6 +146,7 @@ button {
 	border: none;
 	font-size: 3rem;
 	color: #eee;
+	cursor: pointer;
 }
 
 footer {
@@ -173,13 +174,17 @@ footer p {
 	font-size: 1.2rem;
 }
 
-@media screen and (min-width: 768px) and (max-width: 1023px) {
+@media screen and (min-width: 768px) and (max-width: 1180px) {
 	body {
 		font-size: 1.8rem;
 	}
 
+	header, footer {
+		font-size: 1.6rem;
+	}
+
 	header a img {
-		width: 15rem;
+		width: 14rem;
 	}
 
 	.contentxBox ul {
@@ -221,7 +226,7 @@ footer p {
 	}
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1181px) {
 	body {
 		font-size: 2rem;
 	}


### PR DESCRIPTION
1. 가로에 비해 세로가 지나치게 짧아지면 버튼이 컨텐츠와 겹치는 문제를 수정했습니다.

2. @Sooooyeon 해상도 분기를 아래와 같이 변경했습니다.
 - 모바일/태블릿 세로 모드 : 가로 315px 이상 767px 이하
 - 태블릿 가로 모드 : 가로 768px 이상 **1180px** 이하
 - 데스크탑 : 가로 **1181px** 이상